### PR TITLE
chore: relax dependency pins for streamlit deployment

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
-streamlit==1.28.0
-pandas==2.1.0
-plotly==5.17.0
-openai>=1.0.0
-python-dotenv==1.0.0
+streamlit>=1.28,<2
+pandas>=1.5,<3
+plotly>=5,<6
+openai>=1,<2
+python-dotenv>=1,<2

--- a/week-04-integrations/Day_14_AI_Sales_Analytics_Platform/README.md
+++ b/week-04-integrations/Day_14_AI_Sales_Analytics_Platform/README.md
@@ -26,3 +26,11 @@
 - 75% reduction in report generation time
 - Real-time insights for decision making
 - Interactive exploration of data
+
+## Deployment Notes
+- Keep `requirements.txt` in this folder and at the repository root in sync.
+- Dependencies are specified with version ranges to ensure Streamlit Cloud can
+  resolve compatible packages. If deployment fails with a non-zero exit code,
+  verify that the root `requirements.txt` matches this file and reinstall
+  packages using `pip install -r requirements.txt`.
+

--- a/week-04-integrations/Day_14_AI_Sales_Analytics_Platform/requirements.txt
+++ b/week-04-integrations/Day_14_AI_Sales_Analytics_Platform/requirements.txt
@@ -1,5 +1,6 @@
-streamlit==1.28.0
-pandas==2.1.0
-plotly==5.17.0
-openai>=1.0.0
-python-dotenv==1.0.0
+streamlit>=1.28,<2
+pandas>=1.5,<3
+plotly>=5,<6
+openai>=1,<2
+python-dotenv>=1,<2
+


### PR DESCRIPTION
## Summary
- Allow flexible dependency versions to avoid Streamlit Cloud install failures
- Document syncing of requirements files for reliable deployments

## Testing
- `python -m py_compile week-04-integrations/Day_14_AI_Sales_Analytics_Platform/dashboard.py`
- `python -m py_compile test_app.py`


------
https://chatgpt.com/codex/tasks/task_e_689e21ee2238832aa5406c0177995642